### PR TITLE
Add settings object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.4"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements.txt
+install: pip install -r requirements-test.txt
 
 # command to run tests, e.g. python setup.py test
 script: python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ bai2
 .. image:: https://travis-ci.org/ministryofjustice/bai2.svg
     :target: https://travis-ci.org/ministryofjustice/bai2
 
-.. image:: https://coveralls.io/repos/ministryofjustice/bai2/badge.svg&service=github
-    :target: https://coveralls.io/github/ministryofjustice/bai2
+.. image:: https://coveralls.io/repos/ministryofjustice/bai2/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/ministryofjustice/bai2?branch=master
 
 Python module for parsing `BAI2 Files <http://www.bai.org/Libraries/Site-General-Downloads/Cash_Management_2005.sflb.ashx>`_
 
@@ -71,6 +71,14 @@ Models structure::
 Section models define a `header`, a `trailer` and a list of `children` whilst single models define properties matching the bai2 fields.
 
 Each Model has a `rows` property with the original rows from the BAI2 file.
+
+
+Settings
+--------
+
+You can customise the settings using environment vars:
+
+ * **BAI2_IGNORE_INTEGRITY_CHECKS**: if `1`, it disables integrity checks.
 
 
 Exceptions

--- a/bai2/conf.py
+++ b/bai2/conf.py
@@ -1,0 +1,19 @@
+import os
+
+
+class Bai2Settings(object):
+    def __init__(self):
+        self._conf = {}
+
+    def load(self):
+        if not self._conf:
+            self._conf = {
+                'IGNORE_INTEGRITY_CHECKS': os.environ.get(
+                    'BAI2_IGNORE_INTEGRITY_CHECKS', '0'
+                ) == '1'
+            }
+
+    def __getattr__(self, attr):
+        self.load()
+        return self._conf[attr]
+settings = Bai2Settings()

--- a/docs/bai2.rst
+++ b/docs/bai2.rst
@@ -12,6 +12,14 @@ bai2.bai2 module
     :undoc-members:
     :show-inheritance:
 
+bai2.conf module
+----------------
+
+.. automodule:: bai2.conf
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 bai2.constants module
 ---------------------
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+mock==1.3.0

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,0 +1,30 @@
+import mock
+from unittest import TestCase
+
+from bai2.conf import Bai2Settings
+
+
+class Bai2SettingsTestCase(TestCase):
+    def test_defaults(self):
+        """
+        Tests that if no settings are set, use defaults.
+        """
+        settings = Bai2Settings()
+        self.assertFalse(settings.IGNORE_INTEGRITY_CHECKS)
+
+    def test_ignore_integrity_checks_true(self):
+        with mock.patch.dict(
+            'os.environ', {'BAI2_IGNORE_INTEGRITY_CHECKS': '1'}
+        ):
+            settings = Bai2Settings()
+            self.assertTrue(settings.IGNORE_INTEGRITY_CHECKS)
+
+    def test_ignore_integrity_checks_invalid_value(self):
+        """
+        Tests that if the value is != '1', the module ignores it.
+        """
+        with mock.patch.dict(
+            'os.environ', {'BAI2_IGNORE_INTEGRITY_CHECKS': 'invalid'}
+        ):
+            settings = Bai2Settings()
+            self.assertFalse(settings.IGNORE_INTEGRITY_CHECKS)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,4 +1,5 @@
 import datetime
+import mock
 from unittest import TestCase
 
 from bai2.helpers import IteratorHelper
@@ -207,7 +208,7 @@ class AccountParserTestCase(TestCase):
         parser = AccountParser(IteratorHelper(lines))
         self.assertRaises(IntegrityException, parser.parse)
 
-    def tests_fails_integrity_on_account_control_total(self):
+    def test_fails_integrity_on_account_control_total(self):
         """
         Account Control Total == 72000001 when it should be 72000000.
         """
@@ -219,6 +220,24 @@ class AccountParserTestCase(TestCase):
 
         parser = AccountParser(IteratorHelper(lines))
         self.assertRaises(IntegrityException, parser.parse)
+
+    def test_ignore_integrity_checks(self):
+        """
+        Checks that if IGNORE_INTEGRITY_CHECKS is set, integrity checks
+        are not performed.
+        """
+        lines = [
+            '03,0975312468,GBP,010,500000,,,190,70000000,4,0/',
+            '16,165,1500000,1,DD1620,, DEALER PAYMENTS',
+            '49,72000001,3/'
+        ]
+
+        with mock.patch('bai2.parsers.settings') as mocked_settings:
+            mocked_settings.IGNORE_INTEGRITY_CHECKS = True
+
+            parser = AccountParser(IteratorHelper(lines))
+            account = parser.parse()
+            self.assertTrue(isinstance(account, Account))
 
 
 class GroupParserTestCase(TestCase):
@@ -341,7 +360,7 @@ class GroupParserTestCase(TestCase):
         parser = GroupParser(IteratorHelper(lines))
         self.assertRaises(IntegrityException, parser.parse)
 
-    def tests_fails_integrity_on_group_control_total(self):
+    def test_fails_integrity_on_group_control_total(self):
         """
         Group Control Total == 72000001 when it should be 72000000.
         """
@@ -355,6 +374,26 @@ class GroupParserTestCase(TestCase):
 
         parser = GroupParser(IteratorHelper(lines))
         self.assertRaises(IntegrityException, parser.parse)
+
+    def test_ignore_integrity_checks(self):
+        """
+        Checks that if IGNORE_INTEGRITY_CHECKS is set, integrity checks
+        are not performed.
+        """
+        lines = [
+            '02,031001234,122099999,1,040620,2359,GBP,2/',
+            '03,0975312468,GBP,010,500000,,,190,70000000,4,0/',
+            '16,165,1500000,1,DD1620,, DEALER PAYMENTS',
+            '49,72000000,3/',
+            '98,72000001,2,6/'
+        ]
+
+        with mock.patch('bai2.parsers.settings') as mocked_settings:
+            mocked_settings.IGNORE_INTEGRITY_CHECKS = True
+
+            parser = GroupParser(IteratorHelper(lines))
+            group = parser.parse()
+            self.assertTrue(isinstance(group, Group))
 
 
 class Bai2FileParserTestCase(TestCase):
@@ -608,7 +647,7 @@ class Bai2FileParserTestCase(TestCase):
         parser = Bai2FileParser(IteratorHelper(lines))
         self.assertRaises(IntegrityException, parser.parse)
 
-    def tests_fails_integrity_on_file_control_total(self):
+    def test_fails_integrity_on_file_control_total(self):
         """
         File Control Total == 72000001 when it should be 72000000.
         """
@@ -624,3 +663,25 @@ class Bai2FileParserTestCase(TestCase):
 
         parser = Bai2FileParser(IteratorHelper(lines))
         self.assertRaises(IntegrityException, parser.parse)
+
+    def test_ignore_integrity_checks(self):
+        """
+        Checks that if IGNORE_INTEGRITY_CHECKS is set, integrity checks
+        are not performed.
+        """
+        lines = [
+            '01,122099999,123456789,040621,0200,1,,,2/',
+            '02,031001234,122099999,1,040620,2359,GBP,2/',
+            '03,0975312468,GBP,010,500000,,,190,70000000,4,0/',
+            '16,165,1500000,1,DD1620,, DEALER PAYMENTS',
+            '49,72000000,3/',
+            '98,72000000,1,5/',
+            '99,72000001,2,8/'
+        ]
+
+        with mock.patch('bai2.parsers.settings') as mocked_settings:
+            mocked_settings.IGNORE_INTEGRITY_CHECKS = True
+
+            parser = Bai2FileParser(IteratorHelper(lines))
+            bai2_file = parser.parse()
+            self.assertTrue(isinstance(bai2_file, Bai2File))


### PR DESCRIPTION
This adds a settings object and an BAI2_IGNORE_INTEGRITY_CHECKS value which
can be set using env variables.
When set to 1, this disable the integrity checks.
