### PR TITLE
Add unknown availability funds type

### DIFF
--- a/bai2/constants.py
+++ b/bai2/constants.py
@@ -32,6 +32,7 @@ class AsOfDateModifier(Enum):
 
 
 class FundsType(Enum):
+    unknown_availability = 'Z'
     immediate_availability = '0'
     one_day_availability = '1'
     two_day_availability = '2'

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -63,6 +63,27 @@ class TransactionDetailParserTestCase(TestCase):
             'AMALGAMATED CORP. LOCKBOX DEPOSIT-MISC. RECEIVABLES'
         )
 
+    def test_unknown_availability(self):
+        lines = [
+            '16,165,1500000,Z,DD1620,,DEALER PAYMENTS',
+        ]
+
+        ii = IteratorHelper(lines)
+        parser = TransactionDetailParser(ii)
+
+        transaction = parser.parse()
+
+        self.assertEqual(transaction.type_code, TypeCodes['165'])
+        self.assertEqual(transaction.amount, 1500000)
+        self.assertEqual(transaction.funds_type, FundsType.unknown_availability)
+        self.assertEqual(transaction.availability, None)
+        self.assertEqual(transaction.bank_reference, 'DD1620')
+        self.assertEqual(transaction.customer_reference, None)
+        self.assertEqual(
+            transaction.text,
+            'DEALER PAYMENTS'
+        )
+
     def test_value_dated_availability(self):
         lines = [
             '16,191,001,V,150715,2340,1234567890,RP12312312312312/',

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -7,7 +7,7 @@ from bai2 import models, writers, constants
 
 class TransactionDetailWriterTestCase(TestCase):
 
-    def test_transaction_detail_with_default_availability_renders_correctly(self):
+    def test_transaction_detail_with_no_availability_renders_correctly(self):
         transaction = models.TransactionDetail(
             [],
             type_code=constants.TypeCodes['399'],
@@ -17,6 +17,18 @@ class TransactionDetailWriterTestCase(TestCase):
 
         output = writers.TransactionDetailWriter(transaction).write()
         self.assertEqual(output, ['16,399,2599,,,,BILLS'])
+
+    def test_transaction_detail_with_unknown_availability_renders_correctly(self):
+        transaction = models.TransactionDetail(
+            [],
+            type_code=constants.TypeCodes['399'],
+            amount=2599,
+            funds_type=constants.FundsType.unknown_availability,
+            text='BILLS',
+        )
+
+        output = writers.TransactionDetailWriter(transaction).write()
+        self.assertEqual(output, ['16,399,2599,Z,,,BILLS'])
 
     def test_transaction_detail_with_text_on_new_line_renders_correctly(self):
         transaction = models.TransactionDetail(


### PR DESCRIPTION
Supports the unknown availability funds type, indicated with a 'Z'.
Although this is described as the default, it must still be set
explicitly as the funds type field is optional.

Fix for https://github.com/ministryofjustice/bai2/issues/7
