### PR TITLE
make check_integrity propagate to child parsers

### DIFF
--- a/bai2/parsers.py
+++ b/bai2/parsers.py
@@ -41,7 +41,10 @@ class BaseParser(object):
         name = '{name}_parser_class'.format(name=parser_type.lower())
         parser_clazz = getattr(self, name)
         if parser_clazz:
-            return parser_clazz(self._iter)
+            return parser_clazz(
+                self._iter,
+                check_integrity=self.check_integrity,
+            )
         return None
 
     def validate(self, obj):


### PR DESCRIPTION
I noticed that `BaseParser._get_parser()` doesn't pass the value of `check_integrity` to the parser that it creates. I'm not 100% sure whether this is the intended behavior, but here's a patch to fix that if it isn't.
