### PR TITLE
resolving issue when bai file has an empty row in a record

### DIFF
--- a/bai2/helpers.py
+++ b/bai2/helpers.py
@@ -7,7 +7,7 @@ def _build_record(rows):
     for row in rows:
         field_str = row[1]
 
-        if field_str[-1] == '/':
+        if field_str != "" and field_str[-1] == '/':
             fields_str += field_str[:-1] + ','
         else:
             fields_str += field_str + ' '


### PR DESCRIPTION
if bai file contain an empty row line like this
```
88,RECEIVER ID 002097344       DESCRIPTION PAYABLES
88,
88,   00017495533
```
it will throw index out of range exception