### PR TITLE
[Feature] Additional Codes for BOFA

### DIFF
--- a/bai2/constants.py
+++ b/bai2/constants.py
@@ -132,6 +132,7 @@ TypeCodes = [
     TypeCode('150', TypeCodeTransaction.credit, TypeCodeLevel.summary, 'Total Preauthorized Payment Credits'),
     TypeCode('155', TypeCodeTransaction.credit, TypeCodeLevel.detail, 'Preauthorized Draft Credit'),
     TypeCode('156', TypeCodeTransaction.credit, TypeCodeLevel.detail, 'Item in PAC Deposit'),
+    TypeCode('159', TypeCodeTransaction.credit, TypeCodeLevel.summary, 'Total Real Time Payment Credits'),
     TypeCode('160', TypeCodeTransaction.credit, TypeCodeLevel.summary, 'Total ACH Disbursing Funding Credits'),
     TypeCode('162', TypeCodeTransaction.credit, TypeCodeLevel.summary, 'Corporate Trade Payment Settlement'),
     TypeCode('163', TypeCodeTransaction.credit, TypeCodeLevel.summary, 'Corporate Trade Payment Credits'),
@@ -336,6 +337,7 @@ TypeCodes = [
     TypeCode('451', TypeCodeTransaction.debit, TypeCodeLevel.detail, 'ACH Debit Received'),
     TypeCode('452', TypeCodeTransaction.debit, TypeCodeLevel.detail, 'Item in ACH Disbursement or Debit'),
     TypeCode('455', TypeCodeTransaction.debit, TypeCodeLevel.detail, 'Preauthorized ACH Debit'),
+    TypeCode('459', TypeCodeTransaction.debit, TypeCodeLevel.detail, 'Total Real Time Payment Debits'),
     TypeCode('462', TypeCodeTransaction.debit, TypeCodeLevel.detail, 'Account Holder Initiated ACH Debit'),
     TypeCode('463', TypeCodeTransaction.debit, TypeCodeLevel.summary, 'Corporate Trade Payment Debits'),
     TypeCode('464', TypeCodeTransaction.debit, TypeCodeLevel.detail, 'Corporate Trade Payment Debit'),
@@ -527,6 +529,8 @@ TypeCodes = [
     TypeCode('728', TypeCodeTransaction.credit, TypeCodeLevel.detail, 'Amount Applied to Service Charge'),
     TypeCode('760', TypeCodeTransaction.debit, TypeCodeLevel.summary, 'Loan Disbursement'),
     TypeCode('890', TypeCodeTransaction.misc, TypeCodeLevel.detail, 'Contains Non-monetary Information'),
+    TypeCode('906', TypeCodeTransaction.misc, TypeCodeLevel.detail, 'Today’s Opening 1 Day Float'),
+    TypeCode('907', TypeCodeTransaction.misc, TypeCodeLevel.detail, 'Today’s Opening 2+ Day Float'),
 ]
 TypeCodes = {
     type_code.code: type_code


### PR DESCRIPTION
Additional codes I'd like to use for Bank of America files. Not completely sure about the CodeTransaction or CodeLevel enums, let me know what you think.

159 and 459: https://x9.org/wp-content/uploads/2018/07/BTRS-BAI2-Transaction-Codes-and-Format-to-Support-Real-Time-Payments.pdf

906 and 907: https://cashproonline-cdn1.cpoacc.com/cpwportal/cms/public/html/CashProOnline/CPO_Help/Reporting/IRR/PDFs/BAI_Codes.pdf