### PR TITLE
Add support to type codes 827 and 828 and raise more descriptive exception

### DIFF
--- a/bai2/__init__.py
+++ b/bai2/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 8, 2)
+VERSION = (0, 8, 3)
 __version__ = '.'.join(map(str, VERSION))
 __author__ = 'Ministry of Justice Digital & Technology'

--- a/bai2/constants.py
+++ b/bai2/constants.py
@@ -530,6 +530,8 @@ TypeCodes = [
     TypeCode('727', TypeCodeTransaction.credit, TypeCodeLevel.detail, 'Amount Applied to Deferred Interest Detail'),
     TypeCode('728', TypeCodeTransaction.credit, TypeCodeLevel.detail, 'Amount Applied to Service Charge'),
     TypeCode('760', TypeCodeTransaction.debit, TypeCodeLevel.summary, 'Loan Disbursement'),
+    TypeCode('827', TypeCodeTransaction.credit, TypeCodeLevel.summary, 'Incoming SEPA Payments'),
+    TypeCode('828', TypeCodeTransaction.debit, TypeCodeLevel.summary, 'Outgoing SEPA Payments'),
     TypeCode('890', TypeCodeTransaction.misc, TypeCodeLevel.detail, 'Contains Non-monetary Information'),
     TypeCode('906', None, TypeCodeLevel.detail, 'Today’s Opening 1 Day Float'),
     TypeCode('907', None, TypeCodeLevel.detail, 'Today’s Opening 2+ Day Float'),

--- a/bai2/utils.py
+++ b/bai2/utils.py
@@ -2,7 +2,7 @@ import datetime
 import re
 
 from .constants import TypeCodes
-
+from .exceptions import NotSupportedYetException
 
 def parse_date(value):
     """
@@ -66,7 +66,10 @@ def write_military_time(time):
 
 
 def parse_type_code(value):
-    return TypeCodes[value]
+    try:
+        return TypeCodes[value]
+    except KeyError as e:
+        raise NotSupportedYetException(f"Type code '{value}' is not supported yet")
 
 
 def convert_to_string(value):

--- a/bai2/utils.py
+++ b/bai2/utils.py
@@ -68,7 +68,7 @@ def write_military_time(time):
 def parse_type_code(value):
     try:
         return TypeCodes[value]
-    except KeyError as e:
+    except KeyError:
         raise NotSupportedYetException(f"Type code '{value}' is not supported yet")
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -656,3 +656,11 @@ class Bai2FileParserTestCase(TestCase):
         parser = Bai2FileParser(IteratorHelper(lines), check_integrity=False)
         bai2_file = parser.parse()
         self.assertTrue(isinstance(bai2_file, Bai2File))
+
+    def test_unsupported_type_code__should_raise_unsupported_yet_exception(self):
+        lines = [
+            '16,unsupportedCode,1500000,1,DD1620,, DEALER PAYMENTS',
+        ]
+
+        parser = TransactionDetailParser(IteratorHelper(lines))
+        self.assertRaises(NotSupportedYetException, parser.parse)


### PR DESCRIPTION
In case that the type code is not in the `TypeCodes` list, the client gets a `KeyError`.
Instead, now the code will raise a more descriptive exception.
Also, I've added support to 2 type codes: 827 and 828 that are missing from the package.
Here is the reference to these codes:
https://developer.svb.com/apis/account-information-aisp