### PR TITLE
feat(utils): add custom codes support

### DIFF
--- a/bai2/constants.py
+++ b/bai2/constants.py
@@ -538,6 +538,8 @@ TypeCodes = [
     TypeCode('890', TypeCodeTransaction.misc, TypeCodeLevel.detail, 'Contains Non-monetary Information'),
     TypeCode('906', None, TypeCodeLevel.detail, 'Today’s Opening 1 Day Float'),
     TypeCode('907', None, TypeCodeLevel.detail, 'Today’s Opening 2+ Day Float'),
+    TypeCode('920', None, TypeCodeLevel.detail, 'Custom Credit Summary and Detail Code'),
+    TypeCode('960', None, TypeCodeLevel.detail, 'Custom Debit Summary and Detail Code'),
 ]
 TypeCodes = {
     type_code.code: type_code

--- a/bai2/constants.py
+++ b/bai2/constants.py
@@ -538,8 +538,6 @@ TypeCodes = [
     TypeCode('890', TypeCodeTransaction.misc, TypeCodeLevel.detail, 'Contains Non-monetary Information'),
     TypeCode('906', None, TypeCodeLevel.detail, 'Today’s Opening 1 Day Float'),
     TypeCode('907', None, TypeCodeLevel.detail, 'Today’s Opening 2+ Day Float'),
-    TypeCode('920', None, TypeCodeLevel.detail, 'Custom Credit Summary and Detail Code'),
-    TypeCode('960', None, TypeCodeLevel.detail, 'Custom Debit Summary and Detail Code'),
 ]
 TypeCodes = {
     type_code.code: type_code

--- a/bai2/utils.py
+++ b/bai2/utils.py
@@ -67,10 +67,16 @@ def write_military_time(time):
 
 
 def parse_type_code(value):
-    try:
-        return TypeCodes[value]
-    except KeyError:
-        raise NotSupportedYetException(f"Type code '{value}' is not supported yet")
+    type_code = TypeCodes.get(value, None)
+    if type_code is None:
+        if '920' <= value <= '959':
+            type_code = TypeCodes['920']
+        elif '960' <= value <= '999':
+            type_code = TypeCodes['960']
+        else:
+            raise NotSupportedYetException('Type code {} is not supported yet'.format(value))
+    return type_code
+
 
 
 def convert_to_string(value):

--- a/bai2/utils.py
+++ b/bai2/utils.py
@@ -1,7 +1,7 @@
 import datetime
 import re
 
-from .constants import TypeCodes
+from .constants import TypeCodes, TypeCode, TypeCodeLevel
 from .exceptions import NotSupportedYetException
 
 
@@ -70,13 +70,12 @@ def parse_type_code(value):
     type_code = TypeCodes.get(value, None)
     if type_code is None:
         if '920' <= value <= '959':
-            type_code = TypeCodes['920']
+            type_code = TypeCode(value, None, TypeCodeLevel.detail, 'Custom Credit Summary and Detail Code')
         elif '960' <= value <= '999':
-            type_code = TypeCodes['960']
+            type_code = TypeCode(value, None, TypeCodeLevel.detail, 'Custom Debit Summary and Detail Code')
         else:
             raise NotSupportedYetException('Type code {} is not supported yet'.format(value))
     return type_code
-
 
 
 def convert_to_string(value):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -683,6 +683,24 @@ class Bai2FileParserTestCase(TestCase):
         bai2_file = parser.parse()
         self.assertTrue(isinstance(bai2_file, Bai2File))
 
+    def test_custom_type_code_with_code_between_920_and_959__should_return_920_type_code(self):
+        lines = [
+            '16,930,1500000,1,DD1620,, DEALER PAYMENTS',
+        ]
+
+        parser = TransactionDetailParser(IteratorHelper(lines))
+        bai2_file = parser.parse()
+        self.assertEqual(bai2_file.type_code.code, '920')
+
+    def test_custom_type_code_with_code_between_960_and_999__should_return_960_type_code(self):
+        lines = [
+            '16,980,1500000,1,DD1620,, DEALER PAYMENTS',
+        ]
+
+        parser = TransactionDetailParser(IteratorHelper(lines))
+        bai2_file = parser.parse()
+        self.assertEqual(bai2_file.type_code.code, '960')
+
     def test_unsupported_type_code__should_raise_unsupported_yet_exception(self):
         lines = [
             '16,299,1500000,1,DD1620,, DEALER PAYMENTS',

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -683,23 +683,23 @@ class Bai2FileParserTestCase(TestCase):
         bai2_file = parser.parse()
         self.assertTrue(isinstance(bai2_file, Bai2File))
 
-    def test_custom_type_code_with_code_between_920_and_959__should_return_920_type_code(self):
+    def test_custom_type_code_with_code_between_920_and_959__should_return_predefined_type_code_with_given_code(self):
         lines = [
             '16,930,1500000,1,DD1620,, DEALER PAYMENTS',
         ]
 
         parser = TransactionDetailParser(IteratorHelper(lines))
         bai2_file = parser.parse()
-        self.assertEqual(bai2_file.type_code.code, '920')
+        self.assertEqual(bai2_file.type_code.code, '930')
 
-    def test_custom_type_code_with_code_between_960_and_999__should_return_960_type_code(self):
+    def test_custom_type_code_with_code_between_960_and_999__should_return_predefined_type_code_with_given_code(self):
         lines = [
             '16,980,1500000,1,DD1620,, DEALER PAYMENTS',
         ]
 
         parser = TransactionDetailParser(IteratorHelper(lines))
         bai2_file = parser.parse()
-        self.assertEqual(bai2_file.type_code.code, '960')
+        self.assertEqual(bai2_file.type_code.code, '980')
 
     def test_unsupported_type_code__should_raise_unsupported_yet_exception(self):
         lines = [


### PR DESCRIPTION
According to [BAI specification document](https://www.bai.org/docs/default-source/libraries/site-general-downloads/cash_management_2005.pdf) custom codes are not defined and not necessarily supported, but they may fail the parsing flow. On the other hand, we can't map them to anything specific, since different banks map them to different descriptions and codes.

This PR suggests mapping them to type codes with predefined messages but provided code values