### PR TITLE
Fix support for BAI2 files with trailing whitespaces and blank lines

### DIFF
--- a/bai2/bai2.py
+++ b/bai2/bai2.py
@@ -1,6 +1,6 @@
+from bai2.helpers import IteratorHelper
 from bai2.parsers import Bai2FileParser
 from bai2.writers import Bai2FileWriter
-from bai2.helpers import IteratorHelper
 
 
 def parse_from_lines(lines, **kwargs):
@@ -10,12 +10,7 @@ def parse_from_lines(lines, **kwargs):
 
 
 def parse_from_string(s, **kwargs):
-    lines = [
-        line.strip()
-        for line in s.splitlines()
-        if line.strip()
-    ]
-
+    lines = filter(None, (line.strip() for line in s.splitlines()))
     return parse_from_lines(lines, **kwargs)
 
 

--- a/bai2/bai2.py
+++ b/bai2/bai2.py
@@ -10,7 +10,13 @@ def parse_from_lines(lines, **kwargs):
 
 
 def parse_from_string(s, **kwargs):
-    return parse_from_lines(s.splitlines(), **kwargs)
+    lines = [
+        line.strip()
+        for line in s.splitlines()
+        if line.strip()
+    ]
+
+    return parse_from_lines(lines, **kwargs)
 
 
 def parse_from_file(f, **kwargs):

--- a/bai2/helpers.py
+++ b/bai2/helpers.py
@@ -1,5 +1,5 @@
-from .models import Record
 from .constants import RecordCode
+from .models import Record
 
 
 def _build_account_identifier_record(rows):

--- a/tests/test_bai2.py
+++ b/tests/test_bai2.py
@@ -100,6 +100,50 @@ class ParseTestCase(TestCase):
 
         self.assertEqual(original, from_model)
 
+    def test_parse_files_with_trailing_whitespaces(self):
+        original = (
+            '01,123456,123456,220310,0022,1,,,2/                                             \n'
+            '02,,123456,1,220309,,USD,2/                                                     \n'
+            '03,654321,USD,010,10372793,,,015,11384293,,/                                    \n'
+            '16,195,1011500,,12345678912345,Test Transaction/                                \n'
+            '49,22768586,3/                                                                  \n'
+            '98,22768586,1,5/                                                                \n'
+            '99,22768586,1,7/                                                                \n'
+        )
+
+        bai2_file = bai2.parse_from_string(original)
+        self.assertTrue(isinstance(bai2_file, Bai2File))
+
+        from_model = bai2_file.as_string()
+        original_stripped = '\n'.join(['{}'.format(s.strip()) for s in original.splitlines()])
+
+        self.assertEqual(original_stripped, from_model)
+
+    def test_parse_files_with_blank_lines(self):
+        original = (
+            '01,123456,123456,220310,0022,1,,,2/                                             \n'
+            '\n'
+            '02,,123456,1,220309,,USD,2/                                                     \n'
+            '\n'
+            '03,654321,USD,010,10372793,,,015,11384293,,/                                    \n'
+            '\n'
+            '16,195,1011500,,12345678912345,Test Transaction/                                \n'
+            '\n'
+            '49,22768586,3/                                                                  \n'
+            '\n'
+            '98,22768586,1,5/                                                                \n'
+            '\n'
+            '99,22768586,1,7/                                                                \n'
+        )
+
+        bai2_file = bai2.parse_from_string(original)
+        self.assertTrue(isinstance(bai2_file, Bai2File))
+
+        from_model = bai2_file.as_string()
+        original_stripped = '\n'.join(['{}'.format(s.strip()) for s in original.splitlines() if s.strip()])
+
+        self.assertEqual(original_stripped, from_model)
+
 
 class WriteTestCase(TestCase):
     def test_write(self):


### PR DESCRIPTION
## Description
Related to https://github.com/ministryofjustice/bai2/issues/32
I've seen banks sending files with trailing whitespaces _and_ blank lines, which the current version of the library fails to parse, raising an error.

## Solution
Added a `strip` call alongside a conditional to only add lines that have any content.

## Testing
Added two unit tests with the cases specified.

