### PR TITLE
Note that clients of this library can add custom transaction types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,14 @@ It is expected to work correctly with files produced by NatWest, RBS, and JP Mor
 We don't know yet how to deal with these cases as we don't have access to many bai2 files so we can't test it as we would like.
 You can help by submitting pull requests with sample bai2 files.
 
+For parsing custom transaction type codes that are specific to your use case, you can try overriding the default set:
+
+.. code-block:: python
+
+    from bai2.constants import TypeCodes, TypeCode, TypeCodeLevel, TypeCodeTransaction
+
+    TypeCodes['299'] = TypeCode('299', TypeCodeTransaction.credit, TypeCodeLevel.detail, 'Custom transaction')
+
 Development
 -----------
 


### PR DESCRIPTION
`bai2.constants.TypeCodes` is the global dictionary of known transaction types and codes – clients of this library are free to add to or replace these prior to parsing a bai2 file.

Rather than baking in very case-specific transaction types for _all_ users of this library when a new one is reported, it’s worth simply documenting that users can add their own!