### PR TITLE
Improve record-03 parsing

### DIFF
--- a/bai2/helpers.py
+++ b/bai2/helpers.py
@@ -2,7 +2,7 @@ from .constants import RecordCode
 from .models import Record
 
 
-def _build_account_identifier_record(rows):
+def _build_account_identifier_record(rows, include_quirk=True):
     fields_str = ''
     for index, row in enumerate(rows):
         field_str = row[1]
@@ -18,6 +18,9 @@ def _build_account_identifier_record(rows):
                 if summary_commas_count % 4 != 0:
                     # if the number of commas is not a multiple of 4, then we need to add a comma
                     # some banks emit this extra comma, some don't, so we need to normalize it
+                    fields_str += ','
+                elif not include_quirk:
+                    # By spec, all `/` should be a separator
                     fields_str += ','
             else:
                 fields_str += field_str

--- a/bai2/parsers.py
+++ b/bai2/parsers.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 
 from .constants import AsOfDateModifier, FundsType, GroupStatus
 from .exceptions import IntegrityException, NotSupportedYetException, ParsingException
+from .helpers import _build_account_identifier_record
 from .models import (
     Account,
     AccountIdentifier,
@@ -265,6 +266,18 @@ class AccountIdentifierParser(BaseSingleParser):
     ]
 
     def _parse_fields(self, record):
+        try:
+            return self._parse_account_identifier_fields(record)
+        except Exception:
+            # If we failed to builde the record, fall back
+            # to a more spec compliant end of record handling
+            quirk_record = _build_account_identifier_record(
+                record.rows,
+                include_quirk=False,
+            )
+            return self._parse_account_identifier_fields(quirk_record)
+
+    def _parse_account_identifier_fields(self, record):
         model_fields = self._parse_fields_from_config(
             record.fields[:len(self.common_fields_config)],
             self.common_fields_config,

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -25,7 +25,13 @@ from bai2.models import (
     GroupTrailer,
     TransactionDetail,
 )
-from bai2.parsers import AccountParser, Bai2FileParser, GroupParser, TransactionDetailParser
+from bai2.parsers import (
+    AccountIdentifierParser,
+    AccountParser,
+    Bai2FileParser,
+    GroupParser,
+    TransactionDetailParser,
+)
 
 
 class TransactionDetailParserTestCase(TestCase):
@@ -261,6 +267,34 @@ class AccountParserTestCase(TestCase):
         account = parser.parse()
 
         self.assertEqual(len(account.children), 0)
+
+    def test_parse_account_identifier_with_summary_split_across_records(self):
+        lines = [
+            '03,01894102469,USD,010,4764927,,,015,4626045,,,022,0,,,040,4626045,,,045/',
+            '88,4626045,,,072,0,,,074,0,,,076,0,,,100,0,,,400,138882,,/',
+        ]
+
+        parser = AccountIdentifierParser(IteratorHelper(lines))
+
+        header = parser.parse()
+
+        self.assertEqual(header.customer_account_number, '01894102469')
+        self.assertEqual(header.currency, 'USD')
+        self.assertEqual(
+            [(summary.type_code.code, summary.amount) for summary in header.summary_items],
+            [
+                ('010', 4764927),
+                ('015', 4626045),
+                ('022', 0),
+                ('040', 4626045),
+                ('045', 4626045),
+                ('072', 0),
+                ('074', 0),
+                ('076', 0),
+                ('100', 0),
+                ('400', 138882),
+            ],
+        )
 
     def test_parse_with_multiple_transactions(self):
         lines = [


### PR DESCRIPTION
While some banks break the spec by using `,/` as "end of record", more compliant banks correctly use `/`, so a trailing `,/` actually means one empty field.  Additionally, record-03 lines do not have to always be multiples of 4:
* Nothing in the spec says a Summary Code "group" has to be on a single line
* Fund Type of S adds three additional fields
* Fund Type of V adds two additional fields

Any of these cases can break the "multiple of 4" heuristic, leading to extra fields being inserted.  This leads to exceptions like `bai2.exceptions.NotSupportedYetException: Type code '0454626045' is not supported yet` because the wrong field is being parsed as the Type code.